### PR TITLE
Include the offsetParents when locating the target element's position.

### DIFF
--- a/dist/demo.html
+++ b/dist/demo.html
@@ -15,6 +15,7 @@
     <span id="target_2" style="position: fixed; right: 0;">Target #2</span>
     <span id="target_3" style="position: relative; left: 15px; width: 200px; height: 50px; border: 1px solid black; display: block">Target #3</span>
     <span id="target_4" style="position: relative; left: 50%; width: 70px; top: 50%; display: block">Target #4</span>
+    <div style="position: fixed; right: 0; bottom: 0"><span id="target_5">Target #5</span></div>
 
     <script>
         function test() {
@@ -102,6 +103,11 @@
              {
                target: '#target_4',
                content: 'Test 4',
+               color: '#57d80d'
+             },
+             {
+               target: '#target_5',
+               content: 'Test 5',
                color: '#57d80d'
              }
             ]);

--- a/package.json
+++ b/package.json
@@ -6,6 +6,7 @@
   "scripts": {
     "test": "echo \"Error: no test specified\" && exit 1",
     "build": "./node_modules/.bin/rollup -c",
+    "prepare": "rollup -c",
     "build:prod": "NODE_ENV=prod ./node_modules/.bin/rollup -c",
     "release": "npm run build && npm run build:prod && npm publish --tag beta --access=public"
   },

--- a/src/MaterialWalkthrough.js
+++ b/src/MaterialWalkthrough.js
@@ -417,7 +417,7 @@ export default class MaterialWalkthrough {
     // Use the client bounding rect that includes css translation etc.
     const { height, width, left, top } = target.getBoundingClientRect();
     // Adjust the top to be relative to the document
-    const docTop = top + window.scrollY;
+    const docTop = top + window.pageYOffset;
 
     let holeSize = height > width ? height : width; // Catch the biggest measure
     // Adjust with default min measure if it not higher than it

--- a/src/MaterialWalkthrough.js
+++ b/src/MaterialWalkthrough.js
@@ -368,6 +368,21 @@ export default class MaterialWalkthrough {
     }
   }
 
+  /***
+   * Sum the offsetTop and offsetLeft of all parents
+   * @param {HTMLElement} target
+   */
+  static _position(target) {
+    let left = 0;
+    let top = 0;
+    do {
+      left += target.offsetLeft;
+      top += target.offsetTop;
+      target = target.offsetParent;
+    } while (target !== null);
+    return { left, top };
+  }
+
   // @TODO: Animate the scroll.
   /***
    * Centralize the scroll to a target.
@@ -375,7 +390,7 @@ export default class MaterialWalkthrough {
    * @param {function} locateCallback
    */
   static _locateTarget(target, locateCallback) {
-    const top = target.offsetTop;
+    const { top } = _position(target);
     const windowHeight = window.innerHeight;
     const maxScrollValue = MaterialWalkthrough.CURRENT_DOCUMENT_HEIGHT - window.innerHeight;
 
@@ -399,10 +414,9 @@ export default class MaterialWalkthrough {
    * @private
    */
   static _renderFrame(target, renderCallback) {
-    // HAVING ISSUES WITH THIS WAY TO GET POSITION IN SOME TESTS
-     const position = { top: target.offsetTop };
+    const position = _position(target);
     // Using this line.
-    const { height, width, left } = target.getClientRects()[0];
+    const { height, width } = target.getClientRects()[0];
 
     let holeSize = height > width ? height : width; // Catch the biggest measure
     // Adjust with default min measure if it not higher than it
@@ -416,7 +430,7 @@ export default class MaterialWalkthrough {
       marginLeft: -((holeSize + MaterialWalkthrough.GUTTER) / 2) + 'px',
       marginTop: -((holeSize + MaterialWalkthrough.GUTTER) / 2) + 'px',
 
-      left: (left + (width / 2)) + 'px',
+      left: (position.left + (width / 2)) + 'px',
       top: (position.top + (height / 2)) + 'px',
     };
     dom.setStyle(MaterialWalkthrough._wrapper, positions);

--- a/src/MaterialWalkthrough.js
+++ b/src/MaterialWalkthrough.js
@@ -390,7 +390,7 @@ export default class MaterialWalkthrough {
    * @param {function} locateCallback
    */
   static _locateTarget(target, locateCallback) {
-    const { top } = _position(target);
+    const { top } = MaterialWalkthrough._position(target);
     const windowHeight = window.innerHeight;
     const maxScrollValue = MaterialWalkthrough.CURRENT_DOCUMENT_HEIGHT - window.innerHeight;
 
@@ -414,7 +414,7 @@ export default class MaterialWalkthrough {
    * @private
    */
   static _renderFrame(target, renderCallback) {
-    const position = _position(target);
+    const position = MaterialWalkthrough._position(target);
     // Using this line.
     const { height, width } = target.getClientRects()[0];
 

--- a/src/MaterialWalkthrough.js
+++ b/src/MaterialWalkthrough.js
@@ -414,8 +414,9 @@ export default class MaterialWalkthrough {
    * @private
    */
   static _renderFrame(target, renderCallback) {
-    // Use the client bounding rect that includes css translation etc.
-    const { height, width, left, top } = target.getBoundingClientRect();
+    const position = MaterialWalkthrough._position(target);
+    // Using this line.
+    const { height, width } = target.getClientRects()[0];
 
     let holeSize = height > width ? height : width; // Catch the biggest measure
     // Adjust with default min measure if it not higher than it
@@ -429,8 +430,8 @@ export default class MaterialWalkthrough {
       marginLeft: -((holeSize + MaterialWalkthrough.GUTTER) / 2) + 'px',
       marginTop: -((holeSize + MaterialWalkthrough.GUTTER) / 2) + 'px',
 
-      left: (left + (width / 2)) + 'px',
-      top: (top + (height / 2)) + 'px',
+      left: (position.left + (width / 2)) + 'px',
+      top: (position.top + (height / 2)) + 'px',
     };
     dom.setStyle(MaterialWalkthrough._wrapper, positions);
     _log('WALK_LOCK', 'Positioning \n' + JSON.stringify(positions, 2));

--- a/src/MaterialWalkthrough.js
+++ b/src/MaterialWalkthrough.js
@@ -414,9 +414,8 @@ export default class MaterialWalkthrough {
    * @private
    */
   static _renderFrame(target, renderCallback) {
-    const position = MaterialWalkthrough._position(target);
-    // Using this line.
-    const { height, width } = target.getClientRects()[0];
+    // Use the client bounding rect that includes css translation etc.
+    const { height, width, left, top } = target.getBoundingClientRect();
 
     let holeSize = height > width ? height : width; // Catch the biggest measure
     // Adjust with default min measure if it not higher than it
@@ -430,8 +429,8 @@ export default class MaterialWalkthrough {
       marginLeft: -((holeSize + MaterialWalkthrough.GUTTER) / 2) + 'px',
       marginTop: -((holeSize + MaterialWalkthrough.GUTTER) / 2) + 'px',
 
-      left: (position.left + (width / 2)) + 'px',
-      top: (position.top + (height / 2)) + 'px',
+      left: (left + (width / 2)) + 'px',
+      top: (top + (height / 2)) + 'px',
     };
     dom.setStyle(MaterialWalkthrough._wrapper, positions);
     _log('WALK_LOCK', 'Positioning \n' + JSON.stringify(positions, 2));

--- a/src/MaterialWalkthrough.js
+++ b/src/MaterialWalkthrough.js
@@ -414,9 +414,10 @@ export default class MaterialWalkthrough {
    * @private
    */
   static _renderFrame(target, renderCallback) {
-    const position = MaterialWalkthrough._position(target);
-    // Using this line.
-    const { height, width } = target.getClientRects()[0];
+    // Use the client bounding rect that includes css translation etc.
+    const { height, width, left, top } = target.getBoundingClientRect();
+    // Adjust the top to be relative to the document
+    const docTop = top + window.scrollY;
 
     let holeSize = height > width ? height : width; // Catch the biggest measure
     // Adjust with default min measure if it not higher than it
@@ -430,8 +431,8 @@ export default class MaterialWalkthrough {
       marginLeft: -((holeSize + MaterialWalkthrough.GUTTER) / 2) + 'px',
       marginTop: -((holeSize + MaterialWalkthrough.GUTTER) / 2) + 'px',
 
-      left: (position.left + (width / 2)) + 'px',
-      top: (position.top + (height / 2)) + 'px',
+      left: (left + (width / 2)) + 'px',
+      top: (docTop + (height / 2)) + 'px',
     };
     dom.setStyle(MaterialWalkthrough._wrapper, positions);
     _log('WALK_LOCK', 'Positioning \n' + JSON.stringify(positions, 2));


### PR DESCRIPTION
This change totals up the `offsetLeft` and `offsetTop`s of the target element and all its `offsetParent`s to hopefully correctly locate elements that are inside fixed positioned elements, for example.
